### PR TITLE
 Add max_ial and max_aal parameters in registerNode api of NDID node

### DIFF
--- a/docker/start-api.sh
+++ b/docker/start-api.sh
@@ -83,11 +83,11 @@ init_ndid() {
 
 register_node_id() {
   echo "Registering ${NODE_ID} node..."
-
+  
   local PUBLIC_KEY=$(tr '\n' '#' < ${KEY_PATH}.pub | sed 's/#/\\n/g')
   local RESPONSE_CODE=$(curl -sX POST http://${NDID_IP}:${SERVER_PORT}/ndid/registerNode \
     -H "Content-Type: application/json" \
-    -d "{\"public_key\":\"${PUBLIC_KEY}\",\"node_id\":\"${NODE_ID}\",\"role\":\"${ROLE}\"}" \
+    -d "{\"public_key\":\"${PUBLIC_KEY}\",\"node_id\":\"${NODE_ID}\",\"role\":\"${ROLE}\",\"max_ial\":${MAX_IAL:-3},\"max_aal\":${MAX_AAL:-3}}" \
     -w '%{http_code}' \
     -o /dev/null)
 

--- a/src/routes/nationalDigitalIdentity.js
+++ b/src/routes/nationalDigitalIdentity.js
@@ -16,12 +16,14 @@ router.post('/initNDID', async (req, res, next) => {
 
 router.post('/registerNode', async (req, res, next) => {
   try {
-    const { node_id, public_key, role } = req.body;
+    const { node_id, public_key, role, max_aal, max_ial } = req.body;
 
     await abciAppNdid.registerNode({
       node_id,
       public_key,
       role,
+      max_aal,
+      max_ial
     });
 
     res.status(200).end();


### PR DESCRIPTION
Update docker startup script according to https://github.com/ndidplatform/smart-contract/commit/786ba7faffb6722164c8086c5f4971904c2113a3: RegisterNode now requires max_ial and max_aal.