### PR TITLE
Fix failed unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "npx babel src -d ./build/ --source-maps inline && cp -r ./devKey ./build",
     "start": "npm run build && node build/server.js",
     "test": "npm run build && npx mocha build/**/*.test.js",
+    "test:es6": "mocha src/**/*.test.js --watch --compilers js:babel-register",
     "initDevKey": "npm run build && ROLE=ndid node build/devKeyInit.js && npm run delete-local-data-cache",
     "delete-local-data-cache": "rm -rf data",
     "docker-build": "./docker/build.sh",

--- a/src/utils/crypto.test.js
+++ b/src/utils/crypto.test.js
@@ -28,9 +28,13 @@ const expect = chai.expect;
 
 describe('Test crypto functions', () => {
   it('should SHA-256 hash correctly', () => {
+    // action
     const hashed = cryptoUtils.hash('test');
+    // expect
+    // return type is string
     expect(hashed).to.be.a('string');
-    expect(hashed).to.have.lengthOf(64);
+    // return value is base64
+    expect(hashed).to.match(/[A-Za-z0-9+/=]/);
   });
 
   it('should encrypt with public key and decrypt with private key correctly', () => {


### PR DESCRIPTION
- Fix failed case by expecting base64 characters instead of length
- able to run unit tests directly from src folder `npm run test:es6`