### PR TITLE
Replace fixed node name with environment variable

### DIFF
--- a/docker/start-api.sh
+++ b/docker/start-api.sh
@@ -116,9 +116,10 @@ register_node_id() {
   
   local PUBLIC_KEY=$(tr '\n' '#' < ${PUBLIC_KEY_PATH} | sed 's/#/\\n/g')
   local MASTER_PUBLIC_KEY=$(tr '\n' '#' < ${MASTER_PUBLIC_KEY_PATH} | sed 's/#/\\n/g')
+  local NODE_NAME=${NODE_NAME:-"This is name: ${NODE_ID}"}
   local RESPONSE_CODE=$(curl -skX POST ${PROTOCOL}://${NDID_IP}:${NDID_PORT}/ndid/registerNode \
     -H "Content-Type: application/json" \
-    -d "{\"public_key\":\"${PUBLIC_KEY}\",\"master_public_key\":\"${MASTER_PUBLIC_KEY}\",\"node_id\":\"${NODE_ID}\",\"node_name\":\"This is name: ${NODE_ID}\",\"role\":\"${ROLE}\",\"max_ial\":${MAX_IAL:-3},\"max_aal\":${MAX_AAL:-3}}" \
+    -d "{\"public_key\":\"${PUBLIC_KEY}\",\"master_public_key\":\"${MASTER_PUBLIC_KEY}\",\"node_id\":\"${NODE_ID}\",\"node_name\":\"${NODE_NAME}\",\"role\":\"${ROLE}\",\"max_ial\":${MAX_IAL:-3},\"max_aal\":${MAX_AAL:-3}}" \
     -w '%{http_code}' \
     -o /dev/null)
 


### PR DESCRIPTION
I found that platform allows to change API node name, but the start-api.sh script fixed the name and with "This is name: ${NODE_ID}".

I replaced with using environment variable NODE_NAME or put default as existing (This is name: ${NODE_ID}.