### PR TITLE
Add support for error code feature

### DIFF
--- a/main-server/src/core/as/process_data_for_rp.js
+++ b/main-server/src/core/as/process_data_for_rp.js
@@ -229,6 +229,7 @@ async function processDataForRPInternalAsync(
           signature,
           data_salt,
           rpId,
+          error_code,
         },
         { synchronous },
         { nodeId, savedRpId }
@@ -274,6 +275,7 @@ export async function processDataForRPInternalAsyncAfterBlockchain(
     signature,
     data_salt,
     rpId,
+    error_code,
   },
   { synchronous = false } = {},
   { nodeId, savedRpId }
@@ -294,6 +296,7 @@ export async function processDataForRPInternalAsyncAfterBlockchain(
       service_id: serviceId,
       data,
       height,
+      error_code,
     });
 
     if (!synchronous) {

--- a/main-server/src/core/as/process_data_for_rp.js
+++ b/main-server/src/core/as/process_data_for_rp.js
@@ -166,7 +166,7 @@ export async function processDataForRP(
 
 async function processDataForRPInternalAsync(
   data,
-  { reference_id, callback_url, requestId, serviceId, rpId },
+  { reference_id, callback_url, requestId, serviceId, rpId, error_code },
   { synchronous = false } = {},
   { nodeId, savedRpId }
 ) {
@@ -189,6 +189,7 @@ async function processDataForRPInternalAsync(
           request_id: requestId,
           signature,
           service_id: serviceId,
+          error_code,
         },
         nodeId,
         'as.processDataForRPInternalAsyncAfterBlockchain',
@@ -213,6 +214,7 @@ async function processDataForRPInternalAsync(
           request_id: requestId,
           signature,
           service_id: serviceId,
+          error_code,
         },
         nodeId
       );

--- a/main-server/src/core/idp/create_response.js
+++ b/main-server/src/core/idp/create_response.js
@@ -250,6 +250,7 @@ export async function createResponseInternal(
     status,
     accessor_id,
     signature,
+    error_code,
   } = createResponseParams;
   const { nodeId, requestData } = additionalParams;
   try {
@@ -262,6 +263,7 @@ export async function createResponseInternal(
       ial,
       status,
       signature,
+      error_code,
     };
 
     await tendermintNdid.createIdpResponse(

--- a/main-server/src/core/idp/create_response.js
+++ b/main-server/src/core/idp/create_response.js
@@ -279,6 +279,7 @@ export async function createResponseInternal(
           mode,
           accessor_id,
           rp_id: requestData.rp_id,
+          error_code,
         },
       ],
       true
@@ -306,7 +307,7 @@ export async function createResponseInternal(
 
 export async function createResponseAfterBlockchain(
   { height, error, chainDisabledRetryLater },
-  { nodeId, reference_id, callback_url, request_id, mode, accessor_id, rp_id }
+  { nodeId, reference_id, callback_url, request_id, mode, accessor_id, rp_id, error_code }
 ) {
   if (chainDisabledRetryLater) return;
   try {
@@ -319,6 +320,7 @@ export async function createResponseAfterBlockchain(
       accessor_id,
       rp_id,
       height,
+      error_code,
     });
 
     await callbackToClient({
@@ -362,6 +364,7 @@ async function sendResponseToRP({
   accessor_id,
   rp_id,
   height,
+  error_code,
 }) {
   logger.info({
     message: 'Query MQ destination for RP',
@@ -433,6 +436,7 @@ async function sendResponseToRP({
       mode,
       accessor_id,
       idp_id: nodeId,
+      error_code,
       chain_id: tendermint.chainId,
       height,
     },

--- a/main-server/src/core/ndid/index.js
+++ b/main-server/src/core/ndid/index.js
@@ -655,3 +655,30 @@ export async function getNodeIdList(role) {
     throw error;
   }
 }
+
+export async function addErrorCode({
+  error_code, 
+  type, 
+  description, 
+  fatal 
+}) {
+  try {
+    await tendermintNdid.addErrorCode(
+      {error_code, type, description, fatal},
+      config.nodeId
+    );
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function removeErrorCode({ error_code, type }) {
+  try {
+    await tendermintNdid.removeErrorCode(
+      { error_code, type },
+      config.nodeId
+    );
+  } catch (error) {
+    throw error;
+  }
+}

--- a/main-server/src/http_server/routes/v4/as.js
+++ b/main-server/src/http_server/routes/v4/as.js
@@ -110,6 +110,35 @@ router.post(
   }
 );
 
+router.post(
+  '/error/:request_id/:service_id',
+  validateBody,
+  async (req, res, next) => {
+    try {
+      const { request_id, service_id } = req.params;
+      const { node_id, reference_id, callback_url, data, error_code } = req.body;
+
+      await as.processDataForRP(
+        data,
+        {
+          node_id,
+          reference_id,
+          callback_url,
+          requestId: request_id,
+          serviceId: service_id,
+          error_code,
+        },
+        { synchronous: false }
+      );
+
+      res.status(202).end();
+      next();
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
 router.get('/callback', async (req, res, next) => {
   try {
     const urls = await as.getCallbackUrls();

--- a/main-server/src/http_server/routes/v4/idp.js
+++ b/main-server/src/http_server/routes/v4/idp.js
@@ -114,18 +114,11 @@ router.post('/error_response', validateBody, async (req, res, next) => {
       node_id,
       reference_id,
       callback_url,
+      error_code, 
       request_id,
-      //namespace,
-      //identifier,
-      ial,
-      aal,
-      status,
-      accessor_id,
-      signature,
-      error_code,
     } = req.body;
 
-    await idp.createResponse(
+    await idp.createErrorResponse(
       {
         node_id,
         reference_id,
@@ -133,11 +126,7 @@ router.post('/error_response', validateBody, async (req, res, next) => {
         request_id,
         //namespace,
         //identifier,
-        ial,
-        aal,
         status,
-        accessor_id,
-        signature,
         error_code,
       },
       { synchronous: false }

--- a/main-server/src/http_server/routes/v4/idp.js
+++ b/main-server/src/http_server/routes/v4/idp.js
@@ -108,6 +108,48 @@ router.post('/response', validateBody, async (req, res, next) => {
   }
 });
 
+router.post('/error_response', validateBody, async (req, res, next) => {
+  try {
+    const {
+      node_id,
+      reference_id,
+      callback_url,
+      request_id,
+      //namespace,
+      //identifier,
+      ial,
+      aal,
+      status,
+      accessor_id,
+      signature,
+      error_code,
+    } = req.body;
+
+    await idp.createResponse(
+      {
+        node_id,
+        reference_id,
+        callback_url,
+        request_id,
+        //namespace,
+        //identifier,
+        ial,
+        aal,
+        status,
+        accessor_id,
+        signature,
+        error_code,
+      },
+      { synchronous: false }
+    );
+
+    res.status(202).end();
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
+
 router.get(
   '/request_message_padded_hash',
   validateQuery,

--- a/main-server/src/http_server/routes/v4/ndid.js
+++ b/main-server/src/http_server/routes/v4/ndid.js
@@ -536,4 +536,26 @@ router.post('/get_node_id_list', validateBody, async (req, res, next) => {
   }
 });
 
+router.post('/add_error_code', validateBody, async (req, res, next) => {
+  try {
+    const { error_code, type, description, fatal } = req.body;
+    await ndid.addErrorCode({ error_code, type, description, fatal })
+    res.status(204).end();
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/remove_error_code', validateBody, async (req, res, next) => {
+  try {
+    const { error_code, type } = req.body;
+    await ndid.removeErrorCode({ error_code, type });
+    res.status(204).end();
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/main-server/src/http_server/routes/v4/utility.js
+++ b/main-server/src/http_server/routes/v4/utility.js
@@ -201,6 +201,24 @@ router.get('/services/:service_id', async (req, res, next) => {
   }
 });
 
+router.get('/idp_error_codes', async (req, res, next) => {
+  try {
+    res.status(200).json(await tendermintNdid.getErrorCodeList('idp'));
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/as_error_codes', async (req, res, next) => {
+  try {
+    res.status(200).json(await tendermintNdid.getErrorCodeList('as'));
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
+
 // NOTE: Should not be able to get all since it might run into trouble
 // and crash the server if the number of messages are too much to handle
 // (e.g. run out of memory)

--- a/main-server/src/http_server/routes/validator/json_schema/ndid.js
+++ b/main-server/src/http_server/routes/validator/json_schema/ndid.js
@@ -367,5 +367,24 @@ export default {
         },
       },
     },
+    '/ndid/add_error_code': {
+      body: {
+        properties: {
+          error_code: { type: 'string', minLength: 1},
+          type: { type: 'string', enum: ['idp', 'as']},
+          description: { type: 'string' },
+          fatal: { type: 'boolean' }
+        },
+        required: ['error_code', 'type', 'description', 'fatal']
+      }
+    },
+    '/ndid/remove_error_code': {
+      body: {
+        properties: {
+          error_code: { type: 'string', minLength: 1},
+        },
+        required: ['error_code'],
+      }
+    }
   },
 };

--- a/main-server/src/http_server/routes/validator/json_schema/v4.js
+++ b/main-server/src/http_server/routes/validator/json_schema/v4.js
@@ -337,6 +337,18 @@ export default {
         required: ['reference_id', 'callback_url', 'data'],
       },
     },
+    '/as/error/:request_id/:service_id': {
+      body: {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        properties: {
+          node_id: { type: 'string', minLength: 1 },
+          reference_id: { type: 'string', minLength: 1 },
+          callback_url: { $ref: 'defs#/definitions/url' },
+          data: { type: 'string', minLength: 1 },
+        },
+        required: ['reference_id', 'callback_url', 'data'],
+      },
+    },
     '/as/callback': {
       body: {
         $schema: 'http://json-schema.org/draft-07/schema#',

--- a/main-server/src/tendermint/ndid.js
+++ b/main-server/src/tendermint/ndid.js
@@ -1207,6 +1207,19 @@ export async function getNodeInfo(node_id) {
   }
 }
 
+export async function getErrorCodeList(type) {
+  try {
+    return await tendermint.query('GetErrorCodeList', {
+      type,
+    });
+  } catch (error) {
+    throw new CustomError({
+      message: 'Cannot get error code list from blockchain',
+      cause: error,
+    });
+  }
+}
+
 export async function checkExistingAccessorID(accessor_id) {
   try {
     const result = await tendermint.query('CheckExistingAccessorID', {

--- a/main-server/src/tendermint/ndid.js
+++ b/main-server/src/tendermint/ndid.js
@@ -1410,3 +1410,51 @@ export async function getNodeIdList(role) {
     });
   }
 }
+
+export async function addErrorCode(
+  { error_code, type, description, fatal },
+  nodeId,
+  callbackFnName,
+  callbackAdditionalArgs,
+  saveForRetryOnChainDisabled
+) {
+  try {
+    await tendermint.transact({
+      nodeId,
+      fnName: 'AddErrorCode',
+      params: { error_code, type, description, fatal },
+      callbackFnName,
+      callbackAdditionalArgs,
+      saveForRetryOnChainDisabled,
+    });
+  } catch (error) {
+    throw new CustomError({
+      message: 'Cannot add error code',
+      cause: error,
+    });
+  }
+}
+
+export async function removeErrorCode(
+  { error_code, type, },
+  nodeId,
+  callbackFnName,
+  callbackAdditionalArgs,
+  saveForRetryOnChainDisabled
+) {
+  try {
+    await tendermint.transact({
+      nodeId,
+      fnName: 'RemoveErrorCode',
+      params: { error_code, type },
+      callbackFnName,
+      callbackAdditionalArgs,
+      saveForRetryOnChainDisabled,
+    });
+  } catch (error) {
+    throw new CustomError({
+      message: 'Cannot remove error code',
+      cause: error,
+    });
+  }
+}


### PR DESCRIPTION
**DISCLAIMER: This code has not been tested yet**
Changes in this code:
- add `getErrorCodeList`, `addErrorCode` and `removeErrorCode`
- add `error_code` field to `createResponse` and `signASData`
- add new api endpoints `/idp/error_response` and `/as/:request_id/:service_id`