### PR TITLE
[feature/rp message] Add constrain to parameters and Add callback after blockchain

### DIFF
--- a/main-server/src/config.js
+++ b/main-server/src/config.js
@@ -186,6 +186,10 @@ export const autoCloseRequestOnErrored =
 
 //in byte
 export const saltLength = 16;
+//in string
+export const saltStrLength = 24;
+export const messageStrLength = 1024;
+export const purposeStrLength = 512;
 
 // Callback retry timeout in seconds
 export const callbackRetryTimeout = process.env.CALLBACK_RETRY_TIMEOUT

--- a/main-server/src/core/common/create_message.js
+++ b/main-server/src/core/common/create_message.js
@@ -94,11 +94,21 @@ export async function createMessage(
       message_id = utils.createMessageId();
     }
 
-    logger.info(createMessageParams);
+    if (purpose.length > config.purposeStrLength) {
+      throw new CustomError({
+        errorType: errorType.PURPOSE_TOO_LONG,
+      });
+    }
 
     if (hash_message) {
       if (!initial_salt) {
         initial_salt = utils.randomBase64Bytes(config.saltLength);
+      } else {
+        if (initial_salt.length < config.saltStrLength) {
+          throw new CustomError({
+            errorType: errorType.INITIAL_SALT_TOO_SHORT,
+          });
+        }
       }
       const message_salt = utils.generateMessageSalt(initial_salt);
 
@@ -135,6 +145,12 @@ export async function createMessage(
         });
       }
     } else { 
+      if (message.length > config.messageStrLength) {
+        throw new CustomError({
+          errorType: errorType.MESSAGE_TOO_LONG,
+        });
+      }
+
       const messageData = {
         message_id,
         message,

--- a/main-server/src/core/common/create_request.js
+++ b/main-server/src/core/common/create_request.js
@@ -504,6 +504,12 @@ export async function createRequest(
 
     if (!initial_salt) {
       initial_salt = utils.randomBase64Bytes(config.saltLength);
+    } else {
+      if (initial_salt.length < config.saltStrLength) {
+        throw new CustomError({
+          errorType: errorType.INITIAL_SALT_TOO_SHORT,
+        });
+      }
     }
     const request_message_salt = utils.generateRequestMessageSalt(initial_salt);
 

--- a/main-server/src/http_server/routes/v5/rp.js
+++ b/main-server/src/http_server/routes/v5/rp.js
@@ -223,6 +223,7 @@ router.post(
         purpose,
         initial_salt,
         hash_message,
+        callback_url,
       } = req.body;
 
       const result = await common.createMessage(
@@ -233,6 +234,7 @@ router.post(
           purpose,
           initial_salt,
           hash_message,
+          callback_url,
         },
         { synchronous: false }
       );

--- a/main-server/src/http_server/routes/validator/json_schema/v5.js
+++ b/main-server/src/http_server/routes/validator/json_schema/v5.js
@@ -274,6 +274,7 @@ export default {
           properties: {
             node_id: { type: 'string', minLength: 1 },
             reference_id: { type: 'string', minLength: 1 },
+            callback_url: { $ref: 'defs#/definitions/url' },
             message: { type: 'string' },
             purpose: { type: 'string'},
             initial_salt: { type: 'string' },
@@ -281,6 +282,7 @@ export default {
           },
           required: [
             'reference_id',
+            'callback_url',
             'message',
             'purpose',
           ],

--- a/main-server/src/tendermint/ndid.js
+++ b/main-server/src/tendermint/ndid.js
@@ -1465,6 +1465,8 @@ export async function removeErrorCode(
 export async function createMessage(
   messageDataToBlockchain,
   nodeId,
+  callbackFnName,
+  callbackAdditionalArgs,
   saveForRetryOnChainDisabled
 ) {
   try {
@@ -1472,6 +1474,8 @@ export async function createMessage(
       nodeId,
       fnName: 'CreateMessage',
       params: messageDataToBlockchain,
+      callbackFnName,
+      callbackAdditionalArgs,
       saveForRetryOnChainDisabled,
     });
   } catch (error) {

--- a/ndid-error/type.js
+++ b/ndid-error/type.js
@@ -683,6 +683,21 @@ module.exports = {
     message: 'Request has enough AS responses',
     clientError: true,
   },
+  INITIAL_SALT_TOO_SHORT: {
+    code: 20083,
+    message: 'Request has too short initial salt size',
+    clientError: true,
+  },
+  MESSAGE_TOO_LONG: {
+    code: 20084,
+    message: 'Request has too long message',
+    clientError: true,
+  },
+  PURPOSE_TOO_LONG: {
+    code: 20085,
+    message: 'Request has too long purpose',
+    clientError: true,
+  },
 
   // Errors return from ABCI app
   // Server errors


### PR DESCRIPTION
According to Wed. 23th Jun. 2021 meeting, I submitted two commits in this pull request as following:
1. Add constrain to initial_salt, message, and purpose parameters.
- initial_salt string parameter from request and message API size must be larger or equals to 24 characters. (config.saltStrLength, configurable variable like config.saltLength)

- message string parameter from message API size must be less or equals to 1024 characters. (configurable variable via config.messageStrLength)

- purpose string parameter from message API size must be less or equals to 512 characters. (configurable variable via config.purposeStrLength)

- Add new three error types, INITIAL_SALT_TOO_SHORT (20083), MESSAGE_TOO_LONG (20084), and PURPOSE_TOO_LONG (20085), to handle the error that could occur by sending the parameters. 

2. Add callback calls after sent data to TM.

- Add a new required parameter, callback_url, to message API.

- Add callback calls after sent Message to TM.

You can find message swagger format APIs here:
1. POST /rp/message

- https://app.swaggerhub.com/apis/crossknight/rp_message/1.0.0

2. GET /utility/message

- https://app.swaggerhub.com/apis/crossknight/utility_message/1.0.0

3. POST /rp/message/:referenceID (since I reached the maximum number to create APIs for a free account, I will attached it as codes)
```
openapi: 3.0.0
servers:
  - url: 'https://virtserver.swaggerhub.com/ndid/rp_callback/0.1'
info:
  version: "4.0"
  title: RP Message Callback API
  description: API that RP MUST IMPLEMENT to be called by the platform
paths:
  '/rp/message/{reference_id}':
    post:
      summary: Update from NDID
      description: 'Update from NDID to RP, there''s been an update to the status. Note that {reference_id} is NOT automatically append to the registered callback url. This is just an example that you can register callback with reference_id as parameter'
      operationId: request_update
      parameters:
        - name: reference_id
          in: path
          description: Reference ID
          required: true
          schema:
            type: string
      responses:
        '204':
          description: Status Update Acknowledged
      requestBody:
        content:
          application/json:
            schema:
              oneOf:
                - $ref: '#/components/schemas/CallbackCreateMessageResult'
        description: Callback about message
        required: true
components:
  schemas:
    CallbackCreateMessageResult:
      type: object
      required:
        - node_id
        - type
        - reference_id
        - message_id
        - success
      properties:
        node_id:
          type: string
        type:
          type: string
          enum:
            - create_message_result
        reference_id:
          type: string
        message_id:
          type: string
        creation_block_height:
          type: string
          description: '<CHAIN_ID>:<BLOCK_HEIGHT>'
        success:
          type: boolean
        error:
          $ref: '#/components/schemas/Error'
    Error:
      type: object
      required:
        - code
        - message
      properties:
        code:
          type: integer
        message:
          type: string
```